### PR TITLE
Add precompilation workload

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HistoricalStdlibVersions"
 uuid = "6df8b67a-e8a0-4029-b4b7-ac196fe72102"
 authors = ["Ian <i.r.butterworth@gmail.com>"]
-version = "2.0.2"
+version = "2.0.3"
 
 [deps]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/Project.toml
+++ b/Project.toml
@@ -5,8 +5,10 @@ version = "2.0.2"
 
 [deps]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 
 [compat]
+PrecompileTools = "1.2.1"
 julia = "1.7"
 
 [extras]

--- a/src/HistoricalStdlibVersions.jl
+++ b/src/HistoricalStdlibVersions.jl
@@ -5,6 +5,7 @@ Loads historical stdlib version information into Pkg to allow Pkg to resolve std
 """
 module HistoricalStdlibVersions
 using Pkg
+using PrecompileTools: @setup_workload, @compile_workload
 include("StdlibInfo.jl")
 include("version_map.jl")
 
@@ -60,4 +61,11 @@ function __init__()
         register!()
     end
 end
+
+@setup_workload begin
+    @compile_workload begin
+        register!()
+    end
+end
+
 end # module HistoricalStdlibVersions


### PR DESCRIPTION
This reduces package load time from 140ms -> 25ms on my machine, due to precompiling the `__init__()` workload.